### PR TITLE
Synchronizing with recent qubit-toaster changes

### DIFF
--- a/quantastica/qiskit_toaster/ToasterJob.py
+++ b/quantastica/qiskit_toaster/ToasterJob.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class ToasterJob(BaseJob):
-    _MINQTOASTERVERSION = '0.9.8'
+    _MINQTOASTERVERSION = '0.9.9'
     
     _executor = futures.ThreadPoolExecutor()
 
@@ -114,13 +114,13 @@ class ToasterJob(BaseJob):
             shots = qobj_dict['config']['shots']
 
         converted = qobj_to_toaster(qobj_dict, { "all_experiments": False })
-        convertedstr = json.dumps(converted)
 
         args = [
             self._toasterpath,
             "-",
             "-r",
             "measure_all",
+            "-s",
             "%d"%shots
         ]
         if self._getstates:
@@ -131,14 +131,13 @@ class ToasterJob(BaseJob):
         logger.info(args)
         proc = subprocess.run(
             args, 
-            input=convertedstr.encode(),
+            input=converted.encode(),
             stdout=subprocess.PIPE )
 
         qtoasterjson = proc.stdout
 
         resultraw = json.loads(qtoasterjson)
         logger.debug("Raw results from toaster:\r\n%s",resultraw)
-
         if isinstance(resultraw , dict) :
             rawversion = resultraw.get('qtoaster_version')
         else:
@@ -149,7 +148,6 @@ class ToasterJob(BaseJob):
                 "Unsupported qtoaster_version, got '%s' - minimum expected is '%s'.\n\rPlease update your q-toaster to latest version"%(rawversion,self._MINQTOASTERVERSION))
 
         counts = self._convert_counts(resultraw['counts'])
-
         qobjid = qobj_dict['qobj_id']
         qobj_header = qobj_dict['header']
         exp_dict = qobj_dict['experiments'][0]

--- a/quantastica/qiskit_toaster/ToasterJob.py
+++ b/quantastica/qiskit_toaster/ToasterJob.py
@@ -119,7 +119,7 @@ class ToasterJob(BaseJob):
             self._toasterpath,
             "-",
             "-r",
-            "measure_all",
+            "counts",
             "-s",
             "%d"%shots
         ]

--- a/tests/test_toasterbackend.py
+++ b/tests/test_toasterbackend.py
@@ -91,7 +91,6 @@ class TestToasterBackend(unittest.TestCase):
             qc,
             shots
         )
-        self.assertNotEqual(len(stats['counts']), len(stats_aer['counts']))
         self.assertTrue(stats['statevector'] is None)
         self.assertNotEqual(stats['totalcounts'], stats_aer['totalcounts'])
 

--- a/tests/test_toasterbackend.py
+++ b/tests/test_toasterbackend.py
@@ -34,6 +34,7 @@ class TestToasterBackend(unittest.TestCase):
         )
         self.assertTrue( stats['statevector'] is None)
         self.assertEqual( stats['totalcounts'], shots)
+        self.assertEqual( len(stats['counts']), 4)
 
 
     def test_bell_state_vector(self):

--- a/tests/test_toasterbackend.py
+++ b/tests/test_toasterbackend.py
@@ -24,6 +24,17 @@ class TestToasterBackend(unittest.TestCase):
         self.assertEqual( len(stats['counts']), 2)
         self.assertEqual( stats['totalcounts'], shots)
 
+    def test_teleport_counts(self):
+        shots = 256
+        qc=TestToasterBackend.get_teleport_qc()
+        stats = TestToasterBackend.execute_and_get_stats(
+            ToasterBackend.ToasterBackend(),
+            qc,
+            shots
+        )
+        self.assertTrue( stats['statevector'] is None)
+        self.assertEqual( stats['totalcounts'], shots)
+
 
     def test_bell_state_vector(self):
         """
@@ -80,7 +91,6 @@ class TestToasterBackend(unittest.TestCase):
             qc,
             shots
         )
-
         self.assertNotEqual(len(stats['counts']), len(stats_aer['counts']))
         self.assertTrue(stats['statevector'] is None)
         self.assertNotEqual(stats['totalcounts'], stats_aer['totalcounts'])


### PR DESCRIPTION
- pass shots via -s param
- boosted required toaster version to 0.9.9